### PR TITLE
Move keyboard mapping to home-manager :wrench: Darwin native solution is

### DIFF
--- a/mac/darwin-home-config-factory.nix
+++ b/mac/darwin-home-config-factory.nix
@@ -37,4 +37,5 @@ in
     gpg.enable = true;
     zed-editor = zed-config;
   };
+  launchd.agents.keyboard-mapping = import ./keyboard-mapping.nix;
 }

--- a/mac/darwin-module-factory.nix
+++ b/mac/darwin-module-factory.nix
@@ -17,9 +17,5 @@
   security.pam.services.sudo_local.touchIdAuth = true;
   system = {
     stateVersion = 5;
-    keyboard = {
-      enableKeyMapping = true;
-      remapCapsLockToEscape = true;
-    };
   };
 }

--- a/mac/keyboard-mapping.nix
+++ b/mac/keyboard-mapping.nix
@@ -1,0 +1,26 @@
+{
+  enable = true;
+  config = {
+    Label = "org.user.keyboard-mapping";
+    ProgramArguments = [
+      "/usr/bin/hidutil"
+      "property"
+      "--set"
+      (builtins.toJSON {
+        UserKeyMapping = [
+          {
+            HIDKeyboardModifierMappingSrc = 30064771129; # Caps Lock
+            HIDKeyboardModifierMappingDst = 30064771113; # Escape
+          }
+          {
+            HIDKeyboardModifierMappingSrc = 30064771113; # Escape
+            HIDKeyboardModifierMappingDst = 30064771129; # Caps Lock
+          }
+        ];
+      })
+    ];
+    RunAtLoad = true;
+    StandardErrorPath = "/tmp/keyboard-swap.err";
+    StandardOutPath = "/tmp/keyboard-swap.out";
+  };
+}


### PR DESCRIPTION
error prone due initialization might be interrupted during boot :poop: